### PR TITLE
Remove SETUPTOOLS_USE_DISTUTILS = local for py38.

### DIFF
--- a/recipe/0002-remove-setuptools-use-distutils-py38.patch
+++ b/recipe/0002-remove-setuptools-use-distutils-py38.patch
@@ -1,0 +1,11 @@
+--- setup.py.orig	2021-11-02 21:27:26.000000000 -0700
++++ setup.py	2021-11-02 21:27:45.000000000 -0700
+@@ -66,8 +66,6 @@
+ 
+ import sys, os, os.path, pathlib, platform, shutil, tempfile, warnings
+ 
+-# for newer setuptools, enable the embedded distutils before importing setuptools/distutils to avoid warnings
+-os.environ['SETUPTOOLS_USE_DISTUTILS'] = 'local'
+ 
+ from setuptools import setup, Command, Distribution as _Distribution, Extension as _Extension
+ from setuptools.command.build_ext import build_ext as _build_ext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
+    - 0002-remove-setuptools-use-distutils-py38.patch  # [py38]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py36]
   script:
     - python setup.py --with-libyaml build_ext --include-dirs="${PREFIX}/include" --library-dirs="${PREFIX}/lib"  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
-    - 0002-remove-setuptools-use-distutils-py38.patch  # [py38]
+    - 0002-remove-setuptools-use-distutils-py38.patch  # [py==38]
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
-    - 0002-remove-setuptools-use-distutils-py38.patch  # [py==38]
+    - 0002-remove-setuptools-use-distutils-py38.patch  # [py<39]
 
 build:
   number: 2


### PR DESCRIPTION
This option does not properly pass through compiler flags until python 3.9.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/pyyaml-feedstock/issues/38

<!--
Please add any other relevant info below:
-->
